### PR TITLE
CRC validation fix, removed debug logs

### DIFF
--- a/message.go
+++ b/message.go
@@ -1,7 +1,7 @@
 package sml
 
 import (
-	"fmt"
+//	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -134,11 +134,11 @@ func MessageParse(buf *Buffer, validate ...bool) (Message, error) {
 	}
 
 	if len(validate) > 0 && validate[0] {
-		fmt.Println(buf.Cursor)
+//		fmt.Println(buf.Cursor)
 		crc := Crc16Calculate(buf.Bytes[crcStart:crcEnd], crcEnd-crcStart)
-		fmt.Printf("%04x-%04x\n", crc, msg.Crc)
+//		fmt.Printf("%04x-%04x\n", crc, msg.Crc)
 
-		if crc == msg.Crc {
+		if crc != msg.Crc {
 			err := errors.New("Crc error")
 			return msg, err
 		}


### PR DESCRIPTION
Fix the CRC comparison. 

Parsing the sample file `ISKRA_MT175_eHZ.bin` ended up in this error:

```
MessageParse           76 05 0f 1a 20 60 62 00 62 00 72 63 01 01 76 01 01 05 05 08 b5 76 0b 09 01 49 53 4b 00 04
OctetStrParse          05 0f 1a 20 60 62 00 62 00 72 63 01 01 76 01 01 05 05 08 b5 76 0b 09 01 49 53 4b 00 04 03
NumberParse            62 00 62 00 72 63 01 01 76 01 01 05 05 08 b5 76 0b 09 01 49 53 4b 00 04 03 df 63 01 01 63
NumberParse            62 00 72 63 01 01 76 01 01 05 05 08 b5 76 0b 09 01 49 53 4b 00 04 03 df 63 01 01 63 c4 ba
NumberParse            63 01 01 76 01 01 05 05 08 b5 76 0b 09 01 49 53 4b 00 04 03 df 63 01 01 63 c4 ba 00 76 05
OctetStrParse          05 05 08 b5 76 0b 09 01 49 53 4b 00 04 03 df 63 01 01 63 c4 ba 00 76 05 0f 1a 20 61 62 00
OctetStrParse          0b 09 01 49 53 4b 00 04 03 df 63 01 01 63 c4 ba 00 76 05 0f 1a 20 61 62 00 62 00 72 63 07
NumberParse            63 c4 ba 00 76 05 0f 1a 20 61 62 00 62 00 72 63 07 01 77 01 0b 09 01 49 53 4b 00 04 03 df
38
c4ba-c4ba
Crc error
github.com/andig/gosml.MessageParse
        /root/go/pkg/mod/github.com/andig/gosml@v0.0.0-20180619102633-6049058a8802/message.go:142
github.com/andig/gosml.FileParse
        /root/go/pkg/mod/github.com/andig/gosml@v0.0.0-20180619102633-6049058a8802/file.go:17
main.main
        /home/pi/dev/goSML/cmd/main.go:92
runtime.main
        /usr/local/go/src/runtime/proc.go:255
runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1133
```

Even though the file CRC is correct `c4ba-c4ba`
