### PR TITLE
Fix conversion of negative values

### DIFF
--- a/number.go
+++ b/number.go
@@ -88,9 +88,9 @@ func NumberParse(buf *Buffer, numtype uint8, maxSize int) (int64, error) {
 	case TYPENUMBER_8:
 		num = int64(np[0])
 	case TYPENUMBER_16:
-		num = int64(binary.BigEndian.Uint16(np))
+		num = int64(int16(binary.BigEndian.Uint16(np)))
 	case TYPENUMBER_32:
-		num = int64(binary.BigEndian.Uint32(np))
+		num = int64(int32(binary.BigEndian.Uint32(np)))
 	case TYPENUMBER_64:
 		num = int64(binary.BigEndian.Uint64(np))
 	default:


### PR DESCRIPTION
There is an issue when converting negative values. Assume the current power reports a negative value, it is converted into a big int number rather than to a negative value.
This can be verified using this example (https://go.dev/play/p/NldkqwvO6-r) when converting the number `-13`

```
package main

import (
	"encoding/binary"
	"fmt"
)

func main() {
	np := []byte{0xFF, 0xFF, 0xFF, 0xF3} // Signed Int -13

	var num int64
	num = int64(binary.BigEndian.Uint32(np))
	fmt.Println(num)

	num = int64(int32(binary.BigEndian.Uint32(np)))
	fmt.Println(num)
}
```
The output is
```
4294967283
-13

Program exited.
```

I have verified the change with a dump from my meter. 
```
1-0:16.7.0*255               -13.0 W  
1-0:16.7.0*255               -17.0 W  
1-0:16.7.0*255                -9.0 W  
1-0:16.7.0*255                -6.0 W
1-0:16.7.0*255               -20.0 W  
1-0:16.7.0*255                11.0 W  
1-0:16.7.0*255               -24.0 W  
1-0:16.7.0*255                -8.0 W  
1-0:16.7.0*255                 8.0 W  
```

The output matches when I run the same data through libsml:
```
1-0:16.7.0*255#-13#W
1-0:16.7.0*255#-17#W
1-0:16.7.0*255#-9#W
1-0:16.7.0*255#-6#W
1-0:16.7.0*255#-20#W
1-0:16.7.0*255#11#W
1-0:16.7.0*255#-24#W
1-0:16.7.0*255#-8#W
1-0:16.7.0*255#8#W
```