### PR TITLE
Update main.go

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,7 +30,7 @@ func Octet2Obis(o sml.OctetString) string {
 }
 
 func ListEntry2Float(entry sml.ListEntry) float64 {
-	scaler := 1
+	scaler := 0
 	if entry.Scaler != 0 {
 		scaler = int(entry.Scaler)
 	}


### PR DESCRIPTION
Bug ListEntry2Float():
scaler is initalized with 1. This means, if the scaler in the sml entry is 0 the value ist multipied by 10 instead 1.